### PR TITLE
Add Natural Science lesson plan Markdown generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ Repo này lưu trữ và chia sẻ tài liệu dạy học môn Khoa học Tự 
 ## Bản quyền
 - Tài liệu tuân thủ Chương trình GDPT 2018 và công văn Bộ GD&ĐT.
 - Dùng cho mục đích dạy học, không thương mại hóa.
+
+## Công cụ soạn kế hoạch bài dạy (Markdown)
+Ứng dụng dòng lệnh trong thư mục `app/` cho phép tạo giáo án/bài giảng điện tử môn Khoa học Tự nhiên từ tệp JSON và xuất ra Markdown có hỗ trợ công thức LaTeX.
+
+### Cách sử dụng
+1. Tạo tệp cấu hình JSON theo mẫu trong `samples/grade6_light_and_shadow.json`.
+2. Chạy lệnh:
+   ```bash
+   python app/lesson_plan_generator.py path/to/config.json -o path/to/output.md
+   ```
+3. Mở tệp `.md` bằng trình soạn thảo hoặc nền tảng hỗ trợ Markdown/LaTeX để trình chiếu.
+
+
+> 📌 **Lưu ý:** Khi viết công thức LaTeX trong tệp JSON, hãy dùng hai dấu `\` để biểu diễn một dấu `\` thực tế (ví dụ: `\\dfrac{a}{b}` sẽ hiển thị thành `\dfrac{a}{b}`).
+
+### Cấu trúc tệp JSON
+- `metadata`: thông tin bài dạy (tiêu đề, ngày dạy, chủ đề, giáo viên,...).
+- `objectives`, `competencies`, `materials`: danh sách mục tiêu, năng lực và học liệu.
+- `digital_resources`: học liệu số, bài giảng điện tử.
+- `formulas`: danh sách công thức/ký hiệu với trường `latex` giữ nguyên biểu thức.
+- `activities`: mỗi hoạt động gồm thời lượng, mục tiêu, các bước (GV/HS) và học liệu số kèm theo.
+- `assessment`, `homework`, `reflection`: đánh giá, dặn dò và tự nhận xét sau bài học.
+
+Chạy thử với mẫu:
+```bash
+python app/lesson_plan_generator.py samples/grade6_light_and_shadow.json
+```

--- a/app/lesson_plan_generator.py
+++ b/app/lesson_plan_generator.py
@@ -1,0 +1,231 @@
+"""Lesson plan generator for Natural Science lesson plans.
+
+This script reads lesson plan data from a JSON configuration file and
+produces a Markdown document suitable for sharing as a teaching plan or
+digital lesson outline. The generated Markdown keeps LaTeX expressions
+intact so they can be rendered by Markdown viewers that support math.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class Step:
+    """Represents a single step inside an activity."""
+
+    actor: str
+    content: str
+
+    def to_markdown(self, indent: int = 0) -> str:
+        bullet = " " * indent + f"- **{self.actor}**: {self.content.strip()}"
+        return bullet
+
+
+@dataclass
+class Activity:
+    """Represents a teaching activity within the lesson."""
+
+    title: str
+    duration: Optional[str] = None
+    goals: List[str] = field(default_factory=list)
+    steps: List[Step] = field(default_factory=list)
+    digital_assets: List[str] = field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        lines: List[str] = [f"### {self.title}"]
+        if self.duration:
+            lines.append(f"- **Thời lượng**: {self.duration}")
+        if self.goals:
+            lines.append("- **Mục tiêu hoạt động**:")
+            lines.extend("  - " + goal for goal in self.goals)
+        if self.steps:
+            lines.append("- **Tiến trình**:")
+            lines.extend(step.to_markdown(indent=2) for step in self.steps)
+        if self.digital_assets:
+            lines.append("- **Học liệu/Bài giảng điện tử**:")
+            lines.extend("  - " + asset for asset in self.digital_assets)
+        return "\n".join(lines)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def _coerce_steps(raw_steps: Iterable[Dict[str, Any]]) -> List[Step]:
+    steps: List[Step] = []
+    for step in raw_steps:
+        actor = step.get("actor") or "Giáo viên"
+        content = step.get("content") or ""
+        steps.append(Step(actor=actor, content=content))
+    return steps
+
+
+def _coerce_activities(raw_activities: Iterable[Dict[str, Any]]) -> List[Activity]:
+    activities: List[Activity] = []
+    for activity in raw_activities:
+        steps = _coerce_steps(activity.get("steps", []))
+        goals = [goal for goal in activity.get("goals", []) if goal]
+        digital_assets = [asset for asset in activity.get("digital_assets", []) if asset]
+        activities.append(
+            Activity(
+                title=activity.get("title", "Hoạt động"),
+                duration=activity.get("duration"),
+                goals=goals,
+                steps=steps,
+                digital_assets=digital_assets,
+            )
+        )
+    return activities
+
+
+def _format_bullet_section(title: str, items: Iterable[str]) -> Optional[str]:
+    filtered = [item.strip() for item in items if item]
+    if not filtered:
+        return None
+    lines = [f"## {title}"]
+    lines.extend(f"- {item}" for item in filtered)
+    return "\n".join(lines)
+
+
+def _format_table_section(title: str, rows: Iterable[Dict[str, str]], *, headers: List[str]) -> Optional[str]:
+    rows = [row for row in rows if any(row.get(header, "").strip() for header in headers)]
+    if not rows:
+        return None
+
+    lines = [f"## {title}"]
+    header_line = " | ".join(headers)
+    divider_line = " | ".join(["---"] * len(headers))
+    lines.append(f"{header_line}")
+    lines.append(divider_line)
+    for row in rows:
+        line = " | ".join(row.get(header, "").strip() or "-" for header in headers)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def build_markdown(config: Dict[str, Any]) -> str:
+    metadata = config.get("metadata", {})
+    title = metadata.get("title") or "Kế hoạch bài dạy Khoa học Tự nhiên"
+    lesson_date = metadata.get("date") or date.today().isoformat()
+    grade = metadata.get("grade")
+    unit = metadata.get("unit")
+    topic = metadata.get("topic")
+    teacher = metadata.get("teacher")
+    school = metadata.get("school")
+
+    lines: List[str] = [f"# {title}"]
+    info_pairs = [
+        ("Ngày dạy", lesson_date),
+        ("Khối lớp", grade),
+        ("Chủ đề", unit),
+        ("Bài học", topic),
+        ("Giáo viên", teacher),
+        ("Trường", school),
+    ]
+    info_text = [f"- **{label}**: {value}" for label, value in info_pairs if value]
+    if info_text:
+        lines.append("\n".join(info_text))
+
+    objectives = config.get("objectives", [])
+    objectives_section = _format_bullet_section("Mục tiêu bài học", objectives)
+    if objectives_section:
+        lines.append("\n" + objectives_section)
+
+    competencies_section = _format_bullet_section("Năng lực, phẩm chất hình thành", config.get("competencies", []))
+    if competencies_section:
+        lines.append("\n" + competencies_section)
+
+    materials_section = _format_bullet_section("Học liệu và thiết bị", config.get("materials", []))
+    if materials_section:
+        lines.append("\n" + materials_section)
+
+    digital_section = _format_bullet_section(
+        "Bài giảng điện tử và học liệu số", config.get("digital_resources", [])
+    )
+    if digital_section:
+        lines.append("\n" + digital_section)
+
+    formulas = config.get("formulas", [])
+    formula_rows = [
+        {
+            "Ký hiệu": formula.get("symbol", ""),
+            "Diễn giải": formula.get("description", ""),
+            "Biểu thức LaTeX": f"${formula.get('latex', '').strip()}$" if formula.get("latex") else "",
+        }
+        for formula in formulas
+    ]
+    formula_section = _format_table_section(
+        "Công thức và ký hiệu sử dụng", formula_rows, headers=["Ký hiệu", "Diễn giải", "Biểu thức LaTeX"]
+    )
+    if formula_section:
+        lines.append("\n" + formula_section)
+
+    activities = _coerce_activities(config.get("activities", []))
+    if activities:
+        lines.append("\n## Tiến trình dạy học")
+        for activity in activities:
+            lines.append("\n" + activity.to_markdown())
+
+    assessment_section = _format_bullet_section("Đánh giá", config.get("assessment", []))
+    if assessment_section:
+        lines.append("\n" + assessment_section)
+
+    homework_section = _format_bullet_section("Hướng dẫn học tập tiếp theo", config.get("homework", []))
+    if homework_section:
+        lines.append("\n" + homework_section)
+
+    reflection_section = _format_bullet_section("Ghi chú và tự đánh giá", config.get("reflection", []))
+    if reflection_section:
+        lines.append("\n" + reflection_section)
+
+    return "\n\n".join(lines).strip() + "\n"
+
+
+def generate_markdown(config_path: Path, output_path: Path) -> None:
+    config = _read_json(config_path)
+    markdown = build_markdown(config)
+    output_path.write_text(markdown, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Tạo kế hoạch bài dạy/bài giảng điện tử môn Khoa học Tự nhiên ở định dạng Markdown."
+    )
+    parser.add_argument(
+        "config",
+        type=Path,
+        help="Đường dẫn tới tệp JSON mô tả kế hoạch bài dạy.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Đường dẫn tệp Markdown đầu ra. Mặc định cùng thư mục với tệp cấu hình.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config_path: Path = args.config
+    output_path: Path = args.output or config_path.with_suffix(".md")
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"Không tìm thấy tệp cấu hình: {config_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    generate_markdown(config_path, output_path)
+    print(f"✅ Đã tạo kế hoạch bài dạy tại: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/outputs/sample_lesson.md
+++ b/outputs/sample_lesson.md
@@ -1,0 +1,98 @@
+# Bài dạy: Tính chất của Ánh sáng
+
+- **Ngày dạy**: 2024-09-05
+- **Khối lớp**: Lớp 6
+- **Chủ đề**: Chủ đề 2: Ánh sáng
+- **Bài học**: Bài 8: Tán xạ ánh sáng
+- **Giáo viên**: Nguyễn Thị Lan
+- **Trường**: THCS Trần Phú
+
+
+## Mục tiêu bài học
+- Mô tả được hiện tượng tán xạ ánh sáng và lấy được ví dụ trong thực tiễn.
+- Vận dụng được công thức tính cường độ ánh sáng giảm theo khoảng cách: $I = \dfrac{P}{4\pi r^2}$.
+- Rèn luyện năng lực giải quyết vấn đề thông qua phân tích tình huống thực tế.
+
+
+## Năng lực, phẩm chất hình thành
+- Năng lực nhận thức khoa học tự nhiên.
+- Năng lực tìm hiểu tự nhiên.
+- Phẩm chất chăm chỉ, trung thực trong học tập.
+
+
+## Học liệu và thiết bị
+- Phiếu học tập số 1 cho hoạt động thảo luận nhóm.
+- Bộ thí nghiệm đèn laser, màn chắn, khối mờ để minh họa tán xạ.
+- Máy tính, máy chiếu, loa.
+
+
+## Bài giảng điện tử và học liệu số
+- Slide bài giảng điện tử (file .pptx).
+- Mô phỏng PhET: https://phet.colorado.edu/sims/html/laser-basics/latest/laser-basics_vi.html
+- Video minh họa hiện tượng ánh sáng trong sương mù.
+
+
+## Công thức và ký hiệu sử dụng
+Ký hiệu | Diễn giải | Biểu thức LaTeX
+--- | --- | ---
+I | Cường độ ánh sáng tại vị trí quan sát | $I = \dfrac{P}{4\pi r^2}$
+\nabla n | Độ biến thiên chiết suất trong môi trường tán xạ | $\nabla n = \dfrac{\Delta n}{\Delta x}$
+
+
+## Tiến trình dạy học
+
+
+### Khởi động
+- **Thời lượng**: 10 phút
+- **Mục tiêu hoạt động**:
+  - Kết nối kiến thức cũ về đường truyền của ánh sáng.
+  - Gây hứng thú học tập thông qua tình huống thực tế.
+- **Tiến trình**:
+  - **Giáo viên**: Trình chiếu hình ảnh xe chạy trong sương mù và đặt câu hỏi: "Vì sao ta thấy ánh sáng đèn pha tỏa rộng trong sương mù?"
+  - **Học sinh**: Trao đổi cặp đôi và trả lời nhanh trên bảng tương tác.
+- **Học liệu/Bài giảng điện tử**:
+  - Slide 1-2 trong bài giảng điện tử.
+  - Video minh họa 30 giây.
+
+
+### Hình thành kiến thức
+- **Thời lượng**: 20 phút
+- **Mục tiêu hoạt động**:
+  - Học sinh quan sát thí nghiệm để rút ra khái niệm tán xạ ánh sáng.
+  - Giải thích được công thức suy giảm cường độ ánh sáng khi lan truyền.
+- **Tiến trình**:
+  - **Giáo viên**: Tiến hành thí nghiệm chiếu tia laser qua khói, yêu cầu học sinh quan sát tia sáng tán xạ.
+  - **Học sinh**: Ghi chép vào phiếu học tập và thảo luận nhóm nguyên nhân tạo nên chùm sáng.
+  - **Giáo viên**: Giới thiệu công thức $I = \dfrac{P}{4\pi r^2}$ và hướng dẫn cách biến đổi để tính $r$ khi biết $I$ và $P$.
+- **Học liệu/Bài giảng điện tử**:
+  - Slide 5-8 minh họa thí nghiệm.
+  - File mô phỏng PhET hướng dẫn thao tác.
+
+
+### Luyện tập - Vận dụng
+- **Thời lượng**: 15 phút
+- **Mục tiêu hoạt động**:
+  - Củng cố kiến thức bằng bài tập thực tiễn.
+  - Phát triển năng lực giải quyết vấn đề.
+- **Tiến trình**:
+  - **Giáo viên**: Giao nhiệm vụ tính cường độ ánh sáng tại các khoảng cách khác nhau với $P = 120$ W.
+  - **Học sinh**: Làm việc nhóm sử dụng bảng tính hoặc máy tính cầm tay để hoàn thành bảng số liệu.
+  - **Đại diện nhóm**: Trình bày kết quả và nêu ý nghĩa thực tế (ứng dụng trong thiết kế đèn đường).
+- **Học liệu/Bài giảng điện tử**:
+  - Bảng tính Google Sheet chia sẻ qua mã QR.
+  - Slide 10 tổng hợp đáp án.
+
+
+## Đánh giá
+- Quan sát hồ sơ học tập và sản phẩm nhóm trên Google Sheet.
+- Câu hỏi tự luận cuối giờ về ý nghĩa của tán xạ ánh sáng trong đời sống.
+
+
+## Hướng dẫn học tập tiếp theo
+- Hoàn thành bài tập 5 trang 42 SGK, trình bày bằng vở hoặc file .docx.
+- Chuẩn bị cho bài học sau: Tính chất khúc xạ ánh sáng, tìm ví dụ thực tế.
+
+
+## Ghi chú và tự đánh giá
+- Điều chỉnh thời lượng hoạt động luyện tập nếu học sinh gặp khó khăn ở phần tính toán.
+- Cập nhật thêm video minh họa mới nếu có tư liệu hay hơn.

--- a/samples/grade6_light_and_shadow.json
+++ b/samples/grade6_light_and_shadow.json
@@ -1,0 +1,131 @@
+{
+  "metadata": {
+    "title": "Bài dạy: Tính chất của Ánh sáng",
+    "date": "2024-09-05",
+    "grade": "Lớp 6",
+    "unit": "Chủ đề 2: Ánh sáng",
+    "topic": "Bài 8: Tán xạ ánh sáng",
+    "teacher": "Nguyễn Thị Lan",
+    "school": "THCS Trần Phú"
+  },
+  "objectives": [
+    "Mô tả được hiện tượng tán xạ ánh sáng và lấy được ví dụ trong thực tiễn.",
+    "Vận dụng được công thức tính cường độ ánh sáng giảm theo khoảng cách: $I = \\dfrac{P}{4\\pi r^2}$.",
+    "Rèn luyện năng lực giải quyết vấn đề thông qua phân tích tình huống thực tế."
+  ],
+  "competencies": [
+    "Năng lực nhận thức khoa học tự nhiên.",
+    "Năng lực tìm hiểu tự nhiên.",
+    "Phẩm chất chăm chỉ, trung thực trong học tập."
+  ],
+  "materials": [
+    "Phiếu học tập số 1 cho hoạt động thảo luận nhóm.",
+    "Bộ thí nghiệm đèn laser, màn chắn, khối mờ để minh họa tán xạ.",
+    "Máy tính, máy chiếu, loa."
+  ],
+  "digital_resources": [
+    "Slide bài giảng điện tử (file .pptx).",
+    "Mô phỏng PhET: https://phet.colorado.edu/sims/html/laser-basics/latest/laser-basics_vi.html",
+    "Video minh họa hiện tượng ánh sáng trong sương mù."
+  ],
+  "formulas": [
+    {
+      "symbol": "I",
+      "description": "Cường độ ánh sáng tại vị trí quan sát",
+      "latex": "I = \\dfrac{P}{4\\pi r^2}"
+    },
+    {
+      "symbol": "\\nabla n",
+      "description": "Độ biến thiên chiết suất trong môi trường tán xạ",
+      "latex": "\\nabla n = \\dfrac{\\Delta n}{\\Delta x}"
+    }
+  ],
+  "activities": [
+    {
+      "title": "Khởi động",
+      "duration": "10 phút",
+      "goals": [
+        "Kết nối kiến thức cũ về đường truyền của ánh sáng.",
+        "Gây hứng thú học tập thông qua tình huống thực tế."
+      ],
+      "steps": [
+        {
+          "actor": "Giáo viên",
+          "content": "Trình chiếu hình ảnh xe chạy trong sương mù và đặt câu hỏi: \"Vì sao ta thấy ánh sáng đèn pha tỏa rộng trong sương mù?\""
+        },
+        {
+          "actor": "Học sinh",
+          "content": "Trao đổi cặp đôi và trả lời nhanh trên bảng tương tác."
+        }
+      ],
+      "digital_assets": [
+        "Slide 1-2 trong bài giảng điện tử.",
+        "Video minh họa 30 giây."
+      ]
+    },
+    {
+      "title": "Hình thành kiến thức",
+      "duration": "20 phút",
+      "goals": [
+        "Học sinh quan sát thí nghiệm để rút ra khái niệm tán xạ ánh sáng.",
+        "Giải thích được công thức suy giảm cường độ ánh sáng khi lan truyền."
+      ],
+      "steps": [
+        {
+          "actor": "Giáo viên",
+          "content": "Tiến hành thí nghiệm chiếu tia laser qua khói, yêu cầu học sinh quan sát tia sáng tán xạ."
+        },
+        {
+          "actor": "Học sinh",
+          "content": "Ghi chép vào phiếu học tập và thảo luận nhóm nguyên nhân tạo nên chùm sáng."
+        },
+        {
+          "actor": "Giáo viên",
+          "content": "Giới thiệu công thức $I = \\dfrac{P}{4\\pi r^2}$ và hướng dẫn cách biến đổi để tính $r$ khi biết $I$ và $P$."
+        }
+      ],
+      "digital_assets": [
+        "Slide 5-8 minh họa thí nghiệm.",
+        "File mô phỏng PhET hướng dẫn thao tác."
+      ]
+    },
+    {
+      "title": "Luyện tập - Vận dụng",
+      "duration": "15 phút",
+      "goals": [
+        "Củng cố kiến thức bằng bài tập thực tiễn.",
+        "Phát triển năng lực giải quyết vấn đề."
+      ],
+      "steps": [
+        {
+          "actor": "Giáo viên",
+          "content": "Giao nhiệm vụ tính cường độ ánh sáng tại các khoảng cách khác nhau với $P = 120$ W."
+        },
+        {
+          "actor": "Học sinh",
+          "content": "Làm việc nhóm sử dụng bảng tính hoặc máy tính cầm tay để hoàn thành bảng số liệu."
+        },
+        {
+          "actor": "Đại diện nhóm",
+          "content": "Trình bày kết quả và nêu ý nghĩa thực tế (ứng dụng trong thiết kế đèn đường)."
+        }
+      ],
+      "digital_assets": [
+        "Bảng tính Google Sheet chia sẻ qua mã QR.",
+        "Slide 10 tổng hợp đáp án."
+      ]
+    }
+  ],
+  "assessment": [
+    "Quan sát hồ sơ học tập và sản phẩm nhóm trên Google Sheet.",
+    "Câu hỏi tự luận cuối giờ về ý nghĩa của tán xạ ánh sáng trong đời sống."
+  ],
+  "homework": [
+    "Hoàn thành bài tập 5 trang 42 SGK, trình bày bằng vở hoặc file .docx.",
+    "Chuẩn bị cho bài học sau: Tính chất khúc xạ ánh sáng, tìm ví dụ thực tế."
+  ],
+  "reflection": [
+    "Điều chỉnh thời lượng hoạt động luyện tập nếu học sinh gặp khó khăn ở phần tính toán.",
+    "Cập nhật thêm video minh họa mới nếu có tư liệu hay hơn."
+  ]
+}


### PR DESCRIPTION
## Summary
- add a command-line lesson plan generator that converts JSON lesson data into Markdown with LaTeX support
- document the workflow and provide a sample configuration plus generated Markdown output for a Grade 6 optics lesson

## Testing
- python app/lesson_plan_generator.py samples/grade6_light_and_shadow.json -o outputs/sample_lesson.md

------
https://chatgpt.com/codex/tasks/task_e_68d905c288b483219a9958fa1d4e8fd9